### PR TITLE
Implement lane change stability and safety controls

### DIFF
--- a/docs/INSTRUCTIONS.md
+++ b/docs/INSTRUCTIONS.md
@@ -69,6 +69,13 @@ Policy overlays bias the incentive:
 
 Driver parameters (politeness, lane change threshold, right-pass bias) determine the numeric impact.
 
+### Lane Change Stability & Safety
+
+- **Cooldown & Hysteresis** — Each driver now tracks the last executed lane change and enforces a cooldown window in addition to policy “stickiness.” A pending maneuver must first exceed the driver's `EnterThreshold` before being latched as intent, and it will only execute on a subsequent evaluation when the incentive remains above `ExitThreshold`. This hysteresis prevents rapid ping-ponging between lanes.
+- **Gap Acceptance with TTC** — The MOBIL incentive is gated by explicit gap and time-to-collision checks. A candidate lane is only accepted when both front and rear gaps exceed absolute distance minima and the TTC against the target lead/follower stays above driver-specific limits, ensuring merges happen into feasible openings.
+- **Do-No-Harm Rule** — Beyond classic MOBIL safety, a maneuver is rejected if it would force the target follower to brake harder than the configured comfort deceleration (`DeltaAT`) or if it would create sub-threshold TTC conflicts. Vehicles also perform a geometric overlap guard before committing, so no merge can cause an immediate collision.
+- **Configurable Parameters** — The new controls surface through `DriverParams` (cooldown seconds, min gaps, TTCs, enter/exit thresholds) and `LanePolicyConfig` (follower decel allowance, return-right bias, recent-change penalty, sticky seconds). Tune these per profile or policy to balance throughput against stability.
+
 ## Simulation Interfaces
 
 `ISimulation` exposes deterministic control:

--- a/src/Sim.Core/Model/DriverProfile.cs
+++ b/src/Sim.Core/Model/DriverProfile.cs
@@ -19,18 +19,33 @@ public sealed record DriverParams(
     double Politeness,
     double LaneChangeThreshold,
     bool KeepRightBias,
-    double RightPassBias);
+    double RightPassBias,
+
+    // stability / safety knobs
+    double LaneChangeCooldownSec,
+    double MinFrontGapM,
+    double MinRearGapM,
+    double MinFrontTtcSec,
+    double MinRearTtcSec,
+    double EnterThreshold,
+    double ExitThreshold);
 
 public static class DriverCatalog
 {
     private static readonly IReadOnlyDictionary<DriverProfile, DriverParams> Catalog = new Dictionary<DriverProfile, DriverParams>
     {
-        [DriverProfile.Normal] = new(1.00, 1.2, 0.3, 0.20, true, 0.0),
-        [DriverProfile.Speeder] = new(1.15, 1.1, 0.2, 0.10, true, 0.0),
-        [DriverProfile.LaneChanger] = new(1.05, 1.0, 0.15, 0.05, true, 0.0),
-        [DriverProfile.Undertaker] = new(1.05, 1.1, 0.2, 0.10, false, 0.6),
-        [DriverProfile.Hogger] = new(1.02, 1.3, 0.4, 0.40, false, 0.0),
-        [DriverProfile.Timid] = new(0.95, 1.8, 0.5, 0.35, true, 0.0)
+        [DriverProfile.Normal] = new(1.00, 1.2, 0.3, 0.20, true, 0.0,
+            4.0, 8.0, 10.0, 2.0, 2.5, 0.25, 0.10),
+        [DriverProfile.Speeder] = new(1.15, 1.1, 0.2, 0.10, true, 0.0,
+            3.0, 7.0, 9.0, 2.0, 2.5, 0.20, 0.08),
+        [DriverProfile.LaneChanger] = new(1.05, 1.0, 0.15, 0.05, true, 0.0,
+            2.5, 6.0, 8.0, 2.0, 2.5, 0.18, 0.06),
+        [DriverProfile.Undertaker] = new(1.05, 1.1, 0.2, 0.10, false, 0.6,
+            5.0, 8.0, 10.0, 2.0, 2.5, 0.22, 0.08),
+        [DriverProfile.Hogger] = new(1.02, 1.3, 0.4, 0.40, false, 0.0,
+            6.0, 8.0, 10.0, 2.0, 2.5, 0.30, 0.12),
+        [DriverProfile.Timid] = new(0.95, 1.8, 0.5, 0.35, true, 0.0,
+            5.5, 12.0, 15.0, 3.5, 4.0, 0.32, 0.14)
     };
 
     public static DriverParams Lookup(DriverProfile profile)

--- a/src/Sim.Core/Model/LanePolicy.cs
+++ b/src/Sim.Core/Model/LanePolicy.cs
@@ -8,8 +8,8 @@ public enum LanePolicy
 }
 
 public sealed record LanePolicyConfig(
-    LanePolicy Policy,
-    double SafetyDecelThreshold,
-    double KeepRightBonus,
-    double LeftPenalty,
-    double UndertakeBonus);
+    LanePolicy Policy = LanePolicy.KeepRight,
+    double DeltaAT = 0.3,
+    double ReturnRightThreshold = 0.5,
+    double RecentChangePenalty = 0.3,
+    double StickySeconds = 3.0);

--- a/src/Sim.Core/Sim/LaneChangeSafety.cs
+++ b/src/Sim.Core/Sim/LaneChangeSafety.cs
@@ -1,0 +1,33 @@
+using System;
+
+namespace Sim.Core.Sim;
+
+internal static class LaneChangeSafety
+{
+    // Compute time-to-collision: if relV <= 0 (opening), return +INF
+    public static double Ttc(double gapMeters, double relSpeedMps)
+        => relSpeedMps <= 0 ? double.PositiveInfinity : gapMeters / relSpeedMps;
+
+    // Gap acceptance in target lane given my speed and neighbors
+    public static bool AcceptsGap(
+        double myS, double myV, double leadS, double leadV, double follS, double follV,
+        double minFrontGapM, double minRearGapM, double minFrontTtc, double minRearTtc)
+    {
+        // Normalize gaps along S (assume same lane centerline projection)
+        double frontGap = Math.Max(0, leadS - myS);
+        double rearGap = Math.Max(0, myS - follS);
+
+        // TTC toward lead (I approach them)
+        double frontTtc = Ttc(frontGap, Math.Max(0, myV - leadV));
+        // TTC for follower toward me (they approach me)
+        double rearTtc = Ttc(rearGap, Math.Max(0, follV - myV));
+
+        bool gapOK =
+            frontGap >= minFrontGapM &&
+            rearGap >= minRearGapM &&
+            frontTtc >= minFrontTtc &&
+            rearTtc >= minRearTtc;
+
+        return gapOK;
+    }
+}

--- a/tests/Sim.Core.Tests/DoNoHarmFollowerBrakeTests.cs
+++ b/tests/Sim.Core.Tests/DoNoHarmFollowerBrakeTests.cs
@@ -1,0 +1,95 @@
+using System.Collections;
+using Sim.Core.Model;
+using Sim.Core.Sim;
+using Sim.Core.Sim.Seeding;
+using Xunit;
+
+namespace Sim.Core.Tests;
+
+public class DoNoHarmFollowerBrakeTests
+{
+    private static (HighwaySim sim, IDictionary vehicles, VehicleAgent me, VehicleAgent slowLeader, VehicleAgent targetLead, VehicleAgent targetFollower) CreateScenario(double deltaAt)
+    {
+        var network = new HighwayNetwork(2, 3.7, 500, 33.33);
+        var sim = HighwaySimulationFactory.Create(network, TrafficMixes.KeepRightDiscipline);
+        sim.Apply(new SetLanePolicy(new LanePolicyConfig(LanePolicy.KeepRight, deltaAt, 0.6, 0.1, 0.5)));
+
+        var baseDriver = DriverCatalog.Lookup(DriverProfile.Normal);
+        var driver = baseDriver with
+        {
+            LaneChangeThreshold = -0.5,
+            LaneChangeCooldownSec = 2.0,
+            EnterThreshold = 0.05,
+            ExitThreshold = 0.02
+        };
+
+        var me = HighwayTestHelper.CreateAgent(30, VehicleClass.Car, DriverProfile.Normal, driver);
+        var slowLeader = HighwayTestHelper.CreateAgent(31, VehicleClass.Car, DriverProfile.Normal);
+        var targetLead = HighwayTestHelper.CreateAgent(32, VehicleClass.Car, DriverProfile.Normal);
+        var targetFollower = HighwayTestHelper.CreateAgent(33, VehicleClass.Car, DriverProfile.Normal);
+
+        sim.Apply(new SpawnVehicle(0, me));
+        sim.Apply(new SpawnVehicle(0, slowLeader));
+        sim.Apply(new SpawnVehicle(0, targetLead));
+        sim.Apply(new SpawnVehicle(0, targetFollower));
+        sim.Step(0);
+
+        var vehicles = HighwayTestHelper.GetRuntimeDictionary(sim);
+        return (sim, vehicles, me, slowLeader, targetLead, targetFollower);
+    }
+
+    private static void SetupBase(IDictionary vehicles, VehicleAgent me, VehicleAgent slowLeader)
+    {
+        HighwayTestHelper.SetState(vehicles, me.Id, 0, 50, 22);
+        HighwayTestHelper.SetState(vehicles, slowLeader.Id, 0, 60, 10);
+    }
+
+    [Fact]
+    public void RejectsLaneChangeWhenFollowerRequiresHarshBraking()
+    {
+        var (sim, vehicles, me, slowLeader, targetLead, targetFollower) = CreateScenario(0.3);
+
+        SetupBase(vehicles, me, slowLeader);
+        HighwayTestHelper.SetState(vehicles, targetLead.Id, 1, 130, 28);
+        HighwayTestHelper.SetState(vehicles, targetFollower.Id, 1, 40, 35);
+
+        sim.Step(0.2);
+        Assert.Equal(1, HighwayTestHelper.GetProperty<int>(vehicles, me.Id, "PendingTargetLane"));
+
+        SetupBase(vehicles, me, slowLeader);
+        HighwayTestHelper.SetState(vehicles, targetLead.Id, 1, 130, 28);
+        HighwayTestHelper.SetState(vehicles, targetFollower.Id, 1, 40, 35);
+        sim.Step(0.2);
+
+        Assert.Equal(0, HighwayTestHelper.GetLaneIndex(vehicles, me.Id));
+
+        for (var i = 0; i < 8; i++)
+        {
+            SetupBase(vehicles, me, slowLeader);
+            HighwayTestHelper.SetState(vehicles, targetLead.Id, 1, 130, 28);
+            HighwayTestHelper.SetState(vehicles, targetFollower.Id, 1, 40, 35);
+            sim.Step(0.2);
+            Assert.Equal(0, HighwayTestHelper.GetLaneIndex(vehicles, me.Id));
+        }
+    }
+
+    [Fact]
+    public void AllowsLaneChangeWhenFollowerBrakeIsComfortable()
+    {
+        var (sim, vehicles, me, slowLeader, targetLead, targetFollower) = CreateScenario(0.3);
+
+        SetupBase(vehicles, me, slowLeader);
+        HighwayTestHelper.SetState(vehicles, targetLead.Id, 1, 130, 28);
+        HighwayTestHelper.SetState(vehicles, targetFollower.Id, 1, 10, 20);
+
+        sim.Step(0.2);
+        Assert.Equal(1, HighwayTestHelper.GetProperty<int>(vehicles, me.Id, "PendingTargetLane"));
+
+        SetupBase(vehicles, me, slowLeader);
+        HighwayTestHelper.SetState(vehicles, targetLead.Id, 1, 130, 28);
+        HighwayTestHelper.SetState(vehicles, targetFollower.Id, 1, 10, 20);
+        sim.Step(0.2);
+
+        Assert.Equal(1, HighwayTestHelper.GetLaneIndex(vehicles, me.Id));
+    }
+}

--- a/tests/Sim.Core.Tests/GapAcceptanceTests.cs
+++ b/tests/Sim.Core.Tests/GapAcceptanceTests.cs
@@ -1,0 +1,98 @@
+using System.Collections;
+using Sim.Core.Model;
+using Sim.Core.Sim;
+using Sim.Core.Sim.Seeding;
+using Xunit;
+
+namespace Sim.Core.Tests;
+
+public class GapAcceptanceTests
+{
+    private static (HighwaySim sim, IDictionary vehicles, VehicleAgent me, VehicleAgent slowLeader, VehicleAgent targetLead, VehicleAgent targetFollower) CreateScenario()
+    {
+        var network = new HighwayNetwork(2, 3.7, 500, 33.33);
+        var sim = HighwaySimulationFactory.Create(network, TrafficMixes.KeepRightDiscipline);
+        sim.Apply(new SetLanePolicy(new LanePolicyConfig(LanePolicy.KeepRight, 0.3, 0.6, 0.1, 0.5)));
+
+        var baseDriver = DriverCatalog.Lookup(DriverProfile.Normal);
+        var driver = baseDriver with
+        {
+            LaneChangeThreshold = -0.5,
+            LaneChangeCooldownSec = 2.0,
+            EnterThreshold = 0.05,
+            ExitThreshold = 0.02
+        };
+
+        var me = HighwayTestHelper.CreateAgent(20, VehicleClass.Car, DriverProfile.Normal, driver);
+        var slowLeader = HighwayTestHelper.CreateAgent(21, VehicleClass.Car, DriverProfile.Normal);
+        var targetLead = HighwayTestHelper.CreateAgent(22, VehicleClass.Car, DriverProfile.Normal);
+        var targetFollower = HighwayTestHelper.CreateAgent(23, VehicleClass.Car, DriverProfile.Normal);
+
+        sim.Apply(new SpawnVehicle(0, me));
+        sim.Apply(new SpawnVehicle(0, slowLeader));
+        sim.Apply(new SpawnVehicle(0, targetLead));
+        sim.Apply(new SpawnVehicle(0, targetFollower));
+        sim.Step(0);
+
+        var vehicles = HighwayTestHelper.GetRuntimeDictionary(sim);
+
+        return (sim, vehicles, me, slowLeader, targetLead, targetFollower);
+    }
+
+    private static void SetupCurrentLane(IDictionary vehicles, VehicleAgent me, VehicleAgent slowLeader)
+    {
+        HighwayTestHelper.SetState(vehicles, me.Id, 0, 50, 25);
+        HighwayTestHelper.SetState(vehicles, slowLeader.Id, 0, 60, 8);
+    }
+
+    [Fact]
+    public void TightGapIsRejected()
+    {
+        var (sim, vehicles, me, slowLeader, targetLead, targetFollower) = CreateScenario();
+
+        SetupCurrentLane(vehicles, me, slowLeader);
+        HighwayTestHelper.SetState(vehicles, targetLead.Id, 1, 56, 22);
+        HighwayTestHelper.SetState(vehicles, targetFollower.Id, 1, 30, 26);
+
+        sim.Step(0.2);
+        Assert.Equal(1, HighwayTestHelper.GetProperty<int>(vehicles, me.Id, "PendingTargetLane"));
+
+        SetupCurrentLane(vehicles, me, slowLeader);
+        HighwayTestHelper.SetState(vehicles, targetLead.Id, 1, 56, 20);
+        HighwayTestHelper.SetState(vehicles, targetFollower.Id, 1, 30, 26);
+        sim.Step(0.2);
+        Assert.Equal(0, HighwayTestHelper.GetLaneIndex(vehicles, me.Id));
+
+        for (var i = 0; i < 10; i++)
+        {
+            SetupCurrentLane(vehicles, me, slowLeader);
+            HighwayTestHelper.SetState(vehicles, targetLead.Id, 1, 56, 18);
+            HighwayTestHelper.SetState(vehicles, targetFollower.Id, 1, 30, 26);
+            sim.Step(0.2);
+            Assert.Equal(0, HighwayTestHelper.GetLaneIndex(vehicles, me.Id));
+        }
+
+        Assert.NotEqual(1, HighwayTestHelper.GetLaneIndex(vehicles, me.Id));
+        Assert.NotEqual(1, HighwayTestHelper.GetProperty<int>(vehicles, me.Id, "PendingTargetLane"));
+    }
+
+    [Fact]
+    public void AdequateGapAllowsMerge()
+    {
+        var (sim, vehicles, me, slowLeader, targetLead, targetFollower) = CreateScenario();
+
+        SetupCurrentLane(vehicles, me, slowLeader);
+        HighwayTestHelper.SetState(vehicles, targetLead.Id, 1, 140, 28);
+        HighwayTestHelper.SetState(vehicles, targetFollower.Id, 1, 0, 24);
+
+        sim.Step(0.2);
+        Assert.Equal(1, HighwayTestHelper.GetProperty<int>(vehicles, me.Id, "PendingTargetLane"));
+
+        SetupCurrentLane(vehicles, me, slowLeader);
+        HighwayTestHelper.SetState(vehicles, targetLead.Id, 1, 140, 28);
+        HighwayTestHelper.SetState(vehicles, targetFollower.Id, 1, 0, 24);
+        sim.Step(0.2);
+
+        Assert.Equal(1, HighwayTestHelper.GetLaneIndex(vehicles, me.Id));
+    }
+}

--- a/tests/Sim.Core.Tests/HighwayTestHelper.cs
+++ b/tests/Sim.Core.Tests/HighwayTestHelper.cs
@@ -1,0 +1,59 @@
+using System.Collections;
+using System.Reflection;
+using Sim.Core.Model;
+using Sim.Core.Sim;
+
+namespace Sim.Core.Tests;
+
+internal static class HighwayTestHelper
+{
+    public static VehicleAgent CreateAgent(long id, VehicleClass vehicleClass, DriverProfile profile, DriverParams? driverOverride = null)
+    {
+        var driver = driverOverride ?? DriverCatalog.Lookup(profile);
+        return new VehicleAgent(id, vehicleClass, profile, VehicleCatalog.Lookup(vehicleClass), driver);
+    }
+
+    public static IDictionary GetRuntimeDictionary(HighwaySim sim)
+    {
+        var field = typeof(HighwaySim).GetField("_vehicles", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        return (IDictionary)field.GetValue(sim)!;
+    }
+
+    public static void SetState(IDictionary dictionary, long id, int lane, double position, double speed)
+    {
+        var runtime = dictionary[id]!;
+        var type = runtime.GetType();
+        type.GetProperty("LaneIndex")!.SetValue(runtime, lane);
+        type.GetProperty("S")!.SetValue(runtime, position);
+        type.GetProperty("Speed")!.SetValue(runtime, speed);
+    }
+
+    public static void SetKinematics(IDictionary dictionary, long id, double position, double speed)
+    {
+        var runtime = dictionary[id]!;
+        var type = runtime.GetType();
+        type.GetProperty("S")!.SetValue(runtime, position);
+        type.GetProperty("Speed")!.SetValue(runtime, speed);
+    }
+
+    public static int GetLaneIndex(IDictionary dictionary, long id)
+    {
+        var runtime = dictionary[id]!;
+        var type = runtime.GetType();
+        return (int)type.GetProperty("LaneIndex")!.GetValue(runtime)!;
+    }
+
+    public static T GetProperty<T>(IDictionary dictionary, long id, string propertyName)
+    {
+        var runtime = dictionary[id]!;
+        var type = runtime.GetType();
+        return (T)type.GetProperty(propertyName)!.GetValue(runtime)!;
+    }
+
+    public static void SetProperty(IDictionary dictionary, long id, string propertyName, object value)
+    {
+        var runtime = dictionary[id]!;
+        var type = runtime.GetType();
+        type.GetProperty(propertyName)!.SetValue(runtime, value);
+    }
+}

--- a/tests/Sim.Core.Tests/HysteresisTests.cs
+++ b/tests/Sim.Core.Tests/HysteresisTests.cs
@@ -1,0 +1,92 @@
+using System.Collections;
+using Sim.Core.Model;
+using Sim.Core.Sim;
+using Sim.Core.Sim.Seeding;
+using Xunit;
+
+namespace Sim.Core.Tests;
+
+public class HysteresisTests
+{
+    private static (HighwaySim sim, IDictionary vehicles, VehicleAgent me, VehicleAgent slowLeader, VehicleAgent rightLead, VehicleAgent rightFollower) CreateScenario()
+    {
+        var network = new HighwayNetwork(2, 3.7, 500, 33.33);
+        var sim = HighwaySimulationFactory.Create(network, TrafficMixes.KeepRightDiscipline);
+        sim.Apply(new SetLanePolicy(new LanePolicyConfig(LanePolicy.KeepRight, 0.3, 0.6, 0.1, 0.5)));
+
+        var baseDriver = DriverCatalog.Lookup(DriverProfile.Normal);
+        var driver = baseDriver with
+        {
+            LaneChangeThreshold = -0.5,
+            LaneChangeCooldownSec = 2.0,
+            MinFrontGapM = 5.0,
+            MinRearGapM = 5.0,
+            MinFrontTtcSec = 1.0,
+            MinRearTtcSec = 1.5,
+            EnterThreshold = 0.05,
+            ExitThreshold = 0.02
+        };
+
+        var me = HighwayTestHelper.CreateAgent(10, VehicleClass.Car, DriverProfile.Normal, driver);
+        var slowLeader = HighwayTestHelper.CreateAgent(11, VehicleClass.Car, DriverProfile.Normal);
+        var rightLead = HighwayTestHelper.CreateAgent(12, VehicleClass.Car, DriverProfile.Speeder);
+        var rightFollower = HighwayTestHelper.CreateAgent(13, VehicleClass.Car, DriverProfile.Normal);
+
+        sim.Apply(new SpawnVehicle(0, me));
+        sim.Apply(new SpawnVehicle(0, slowLeader));
+        sim.Apply(new SpawnVehicle(0, rightLead));
+        sim.Apply(new SpawnVehicle(0, rightFollower));
+        sim.Step(0);
+
+        var vehicles = HighwayTestHelper.GetRuntimeDictionary(sim);
+
+        return (sim, vehicles, me, slowLeader, rightLead, rightFollower);
+    }
+
+    private static void SetupStrongIncentive(IDictionary vehicles, VehicleAgent me, VehicleAgent slowLeader, VehicleAgent rightLead, VehicleAgent rightFollower)
+    {
+        HighwayTestHelper.SetState(vehicles, me.Id, 0, 50, 25);
+        HighwayTestHelper.SetState(vehicles, slowLeader.Id, 0, 60, 8);
+        HighwayTestHelper.SetState(vehicles, rightLead.Id, 1, 130, 28);
+        HighwayTestHelper.SetState(vehicles, rightFollower.Id, 1, 15, 24);
+    }
+
+    [Fact]
+    public void LaneChangeRequiresSustainedIncentive()
+    {
+        var (sim, vehicles, me, slowLeader, rightLead, rightFollower) = CreateScenario();
+
+        SetupStrongIncentive(vehicles, me, slowLeader, rightLead, rightFollower);
+        sim.Step(0.2);
+
+        Assert.Equal(0, HighwayTestHelper.GetLaneIndex(vehicles, me.Id));
+        Assert.Equal(1, HighwayTestHelper.GetProperty<int>(vehicles, me.Id, "PendingTargetLane"));
+
+        SetupStrongIncentive(vehicles, me, slowLeader, rightLead, rightFollower);
+        sim.Step(0.2);
+
+        Assert.Equal(1, HighwayTestHelper.GetLaneIndex(vehicles, me.Id));
+        Assert.Equal(-1, HighwayTestHelper.GetProperty<int>(vehicles, me.Id, "PendingTargetLane"));
+    }
+
+    [Fact]
+    public void PendingCancelsWhenIncentiveFallsBelowExit()
+    {
+        var (sim, vehicles, me, slowLeader, rightLead, rightFollower) = CreateScenario();
+
+        SetupStrongIncentive(vehicles, me, slowLeader, rightLead, rightFollower);
+        sim.Step(0.2);
+        Assert.Equal(1, HighwayTestHelper.GetProperty<int>(vehicles, me.Id, "PendingTargetLane"));
+
+        var currentLane = HighwayTestHelper.GetLaneIndex(vehicles, me.Id);
+        HighwayTestHelper.SetState(vehicles, me.Id, currentLane, 50, 20);
+        HighwayTestHelper.SetState(vehicles, slowLeader.Id, 0, 200, 32);
+        HighwayTestHelper.SetState(vehicles, rightLead.Id, 1, 52, 5);
+        HighwayTestHelper.SetState(vehicles, rightFollower.Id, 1, 40, 5);
+
+        sim.Step(0.2);
+
+        Assert.Equal(0, HighwayTestHelper.GetLaneIndex(vehicles, me.Id));
+        Assert.Equal(-1, HighwayTestHelper.GetProperty<int>(vehicles, me.Id, "PendingTargetLane"));
+    }
+}

--- a/tests/Sim.Core.Tests/LaneChangeCooldownTests.cs
+++ b/tests/Sim.Core.Tests/LaneChangeCooldownTests.cs
@@ -1,0 +1,89 @@
+using System.Collections;
+using Sim.Core.Model;
+using Sim.Core.Sim;
+using Sim.Core.Sim.Seeding;
+using Xunit;
+
+namespace Sim.Core.Tests;
+
+public class LaneChangeCooldownTests
+{
+    [Fact]
+    public void DriverHonorsCooldownBeforeNextLaneChange()
+    {
+        var network = new HighwayNetwork(2, 3.7, 500, 33.33);
+        var sim = HighwaySimulationFactory.Create(network, TrafficMixes.KeepRightDiscipline);
+        sim.Apply(new SetLanePolicy(new LanePolicyConfig(LanePolicy.KeepRight, 0.3, 0.6, 0.1, 0.5)));
+
+        var baseDriver = DriverCatalog.Lookup(DriverProfile.Normal);
+        var testDriver = baseDriver with
+        {
+            LaneChangeThreshold = -0.5,
+            LaneChangeCooldownSec = 4.0,
+            MinFrontGapM = 5.0,
+            MinRearGapM = 5.0,
+            MinFrontTtcSec = 1.0,
+            MinRearTtcSec = 1.5,
+            EnterThreshold = 0.05,
+            ExitThreshold = 0.02
+        };
+
+        var me = HighwayTestHelper.CreateAgent(1, VehicleClass.Car, DriverProfile.Normal, testDriver);
+        var slowLeader = HighwayTestHelper.CreateAgent(2, VehicleClass.Car, DriverProfile.Normal);
+        var rightLead = HighwayTestHelper.CreateAgent(3, VehicleClass.Car, DriverProfile.Speeder);
+        var rightFollower = HighwayTestHelper.CreateAgent(4, VehicleClass.Car, DriverProfile.Normal);
+
+        sim.Apply(new SpawnVehicle(0, me));
+        sim.Apply(new SpawnVehicle(0, slowLeader));
+        sim.Apply(new SpawnVehicle(0, rightLead));
+        sim.Apply(new SpawnVehicle(0, rightFollower));
+        sim.Step(0);
+
+        var vehicles = HighwayTestHelper.GetRuntimeDictionary(sim);
+
+        void SetupLeftScenario()
+        {
+            HighwayTestHelper.SetState(vehicles, me.Id, 0, 50, 25);
+            HighwayTestHelper.SetState(vehicles, slowLeader.Id, 0, 60, 8);
+            HighwayTestHelper.SetState(vehicles, rightLead.Id, 1, 130, 28);
+            HighwayTestHelper.SetState(vehicles, rightFollower.Id, 1, 15, 24);
+        }
+
+        SetupLeftScenario();
+        sim.Step(0.2);
+        Assert.Equal(0, HighwayTestHelper.GetLaneIndex(vehicles, me.Id));
+
+        SetupLeftScenario();
+        sim.Step(0.2);
+        Assert.Equal(1, HighwayTestHelper.GetLaneIndex(vehicles, me.Id));
+        var lastChangeTime = sim.Time;
+
+        void SetupReturnScenario()
+        {
+            var currentLane = HighwayTestHelper.GetLaneIndex(vehicles, me.Id);
+            HighwayTestHelper.SetState(vehicles, me.Id, currentLane, 55, 24);
+            HighwayTestHelper.SetState(vehicles, slowLeader.Id, 1, 65, 8);
+            HighwayTestHelper.SetState(vehicles, rightLead.Id, 0, 130, 30);
+            HighwayTestHelper.SetState(vehicles, rightFollower.Id, 0, 20, 24);
+        }
+
+        SetupReturnScenario();
+        sim.Step(0.2);
+        Assert.Equal(1, HighwayTestHelper.GetLaneIndex(vehicles, me.Id));
+        Assert.True(sim.Time - lastChangeTime < testDriver.LaneChangeCooldownSec);
+
+        var guard = 0;
+        while (sim.Time - lastChangeTime + 1e-6 < testDriver.LaneChangeCooldownSec)
+        {
+            SetupReturnScenario();
+            sim.Step(0.2);
+            Assert.Equal(1, HighwayTestHelper.GetLaneIndex(vehicles, me.Id));
+            guard++;
+            Assert.True(guard < 100, "Cooldown loop exceeded iteration guard");
+        }
+
+        SetupReturnScenario();
+        sim.Step(0.2);
+        Assert.Equal(0, HighwayTestHelper.GetLaneIndex(vehicles, me.Id));
+    }
+}

--- a/tests/Sim.Core.Tests/MobilTests.cs
+++ b/tests/Sim.Core.Tests/MobilTests.cs
@@ -36,7 +36,7 @@ public class MobilTests
         SetState(vehicles, targetFollower.Id, lane: 0, position: 90, speed: 20);
         SetState(vehicles, targetLeader.Id, lane: 0, position: 130, speed: 25);
 
-        sim.Apply(new SetLanePolicy(new LanePolicyConfig(LanePolicy.KeepRight, 2.5, 0.2, 0.1, 0)));
+        sim.Apply(new SetLanePolicy(new LanePolicyConfig(LanePolicy.KeepRight, 2.5, 0.0, 0.0, 1.0)));
         sim.Step(0.5);
 
         var meRuntime = vehicles[me.Id];
@@ -64,7 +64,7 @@ public class MobilTests
         SetState(vehicles, follower.Id, lane: 1, position: 80, speed: 26);
         SetState(vehicles, leader.Id, lane: 1, position: 130, speed: 20);
 
-        sim.Apply(new SetLanePolicy(new LanePolicyConfig(LanePolicy.KeepRight, 4.0, 0.2, 0.1, 0)));
+        sim.Apply(new SetLanePolicy(new LanePolicyConfig(LanePolicy.KeepRight, 4.0, 0.0, 0.0, 1.0)));
         sim.Step(0.5);
 
         var meRuntime = vehicles[me.Id];

--- a/tests/Sim.Core.Tests/NoOverlapTests.cs
+++ b/tests/Sim.Core.Tests/NoOverlapTests.cs
@@ -1,0 +1,86 @@
+using System.Collections;
+using Sim.Core.Model;
+using Sim.Core.Sim;
+using Sim.Core.Sim.Seeding;
+using Xunit;
+
+namespace Sim.Core.Tests;
+
+public class NoOverlapTests
+{
+    private static (HighwaySim sim, IDictionary vehicles, VehicleAgent me, VehicleAgent slowLeader, VehicleAgent targetLead, VehicleAgent targetFollower) CreateScenario()
+    {
+        var network = new HighwayNetwork(2, 3.7, 500, 33.33);
+        var sim = HighwaySimulationFactory.Create(network, TrafficMixes.KeepRightDiscipline);
+        sim.Apply(new SetLanePolicy(new LanePolicyConfig(LanePolicy.KeepRight, 0.3, 0.6, 0.1, 0.5)));
+
+        var baseDriver = DriverCatalog.Lookup(DriverProfile.Normal);
+        var driver = baseDriver with
+        {
+            LaneChangeThreshold = -0.5,
+            LaneChangeCooldownSec = 2.0,
+            EnterThreshold = 0.05,
+            ExitThreshold = 0.02
+        };
+
+        var me = HighwayTestHelper.CreateAgent(40, VehicleClass.Car, DriverProfile.Normal, driver);
+        var slowLeader = HighwayTestHelper.CreateAgent(41, VehicleClass.Car, DriverProfile.Normal);
+        var targetLead = HighwayTestHelper.CreateAgent(42, VehicleClass.Car, DriverProfile.Normal);
+        var targetFollower = HighwayTestHelper.CreateAgent(43, VehicleClass.Car, DriverProfile.Normal);
+
+        sim.Apply(new SpawnVehicle(0, me));
+        sim.Apply(new SpawnVehicle(0, slowLeader));
+        sim.Apply(new SpawnVehicle(0, targetLead));
+        sim.Apply(new SpawnVehicle(0, targetFollower));
+        sim.Step(0);
+
+        var vehicles = HighwayTestHelper.GetRuntimeDictionary(sim);
+        return (sim, vehicles, me, slowLeader, targetLead, targetFollower);
+    }
+
+    private static void SetupBase(IDictionary vehicles, VehicleAgent me, VehicleAgent slowLeader)
+    {
+        HighwayTestHelper.SetState(vehicles, me.Id, 0, 50, 25);
+        HighwayTestHelper.SetState(vehicles, slowLeader.Id, 0, 60, 10);
+    }
+
+    [Fact]
+    public void RejectsLaneChangeThatWouldOverlapTargetVehicles()
+    {
+        var (sim, vehicles, me, slowLeader, targetLead, targetFollower) = CreateScenario();
+
+        SetupBase(vehicles, me, slowLeader);
+        HighwayTestHelper.SetState(vehicles, targetLead.Id, 1, 53, 20);
+        HighwayTestHelper.SetState(vehicles, targetFollower.Id, 1, 20, 18);
+
+        sim.Step(0.2);
+        Assert.Equal(1, HighwayTestHelper.GetProperty<int>(vehicles, me.Id, "PendingTargetLane"));
+
+        SetupBase(vehicles, me, slowLeader);
+        HighwayTestHelper.SetState(vehicles, targetLead.Id, 1, 53, 20);
+        HighwayTestHelper.SetState(vehicles, targetFollower.Id, 1, 20, 18);
+        sim.Step(0.2);
+
+        Assert.Equal(0, HighwayTestHelper.GetLaneIndex(vehicles, me.Id));
+    }
+
+    [Fact]
+    public void AllowsLaneChangeWhenOverlapClears()
+    {
+        var (sim, vehicles, me, slowLeader, targetLead, targetFollower) = CreateScenario();
+
+        SetupBase(vehicles, me, slowLeader);
+        HighwayTestHelper.SetState(vehicles, targetLead.Id, 1, 120, 26);
+        HighwayTestHelper.SetState(vehicles, targetFollower.Id, 1, 10, 18);
+
+        sim.Step(0.2);
+        Assert.Equal(1, HighwayTestHelper.GetProperty<int>(vehicles, me.Id, "PendingTargetLane"));
+
+        SetupBase(vehicles, me, slowLeader);
+        HighwayTestHelper.SetState(vehicles, targetLead.Id, 1, 120, 26);
+        HighwayTestHelper.SetState(vehicles, targetFollower.Id, 1, 10, 18);
+        sim.Step(0.2);
+
+        Assert.Equal(1, HighwayTestHelper.GetLaneIndex(vehicles, me.Id));
+    }
+}

--- a/tests/Sim.Core.Tests/PolicyTests.cs
+++ b/tests/Sim.Core.Tests/PolicyTests.cs
@@ -31,7 +31,7 @@ public class PolicyTests
         var sim = HighwaySimulationFactory.Create(new HighwayNetwork(3, 3.7, 500, 33.33), TrafficMixes.KeepRightDiscipline);
         var agent = CreateAgent(2, VehicleClass.Car, DriverProfile.Hogger);
         sim.Apply(new SpawnVehicle(0, agent));
-        sim.Apply(new SetLanePolicy(new LanePolicyConfig(LanePolicy.Hogging, 3.0, 0.05, 0.05, 0)));
+        sim.Apply(new SetLanePolicy(new LanePolicyConfig(LanePolicy.Hogging, 3.0, 0.05, 0.05, 0.5)));
         sim.Step(0);
 
         var vehicles = GetRuntimeDictionary(sim);


### PR DESCRIPTION
## Summary
- extend driver and lane policy parameters to expose cooldown, gap, and hysteresis controls for lane changes
- gate MOBIL decisions with cooldown, TTC-based gap acceptance, follower decel, and overlap checks to prevent oscillations and unsafe merges
- document the stability features and add targeted unit tests with helpers covering cooldown, hysteresis, gap acceptance, do-no-harm braking, and overlap guards

## Testing
- dotnet test *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e006a4a7648328b8d4895468c1cf41