### PR TITLE
v1: add educational A/B report, host `--report` mode, client HUD and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,107 @@
-Test
+# Keep Right Sim
+
+Keep Right Sim is a deterministic highway traffic simulation and teaching tool that shows why **keeping right except to pass** improves flow for everyone. It compares two versions of the same road:
+
+- **Keep right except to pass**: drivers cruise in the rightmost available lane and use left lanes for active passing.
+- **Hogging / undertaking**: more drivers sit in passing lanes or pass on the wrong side, creating rolling bottlenecks.
+
+The project is intentionally small enough for classroom use, workshops, road-safety campaigns, and policy discussions. It produces both a live ASCII visualization and a reproducible A/B report with journey-time and throughput metrics.
+
+## What learners should discover
+
+- Passing lanes work like shared infrastructure: they help most when they are available for overtaking.
+- A single driver cruising in a passing lane can force queues, extra braking, and lane weaving behind them.
+- Keeping right reduces speed variance and accordion traffic, so slow, normal, and fast vehicles all get more predictable journeys.
+- The benefit is measurable: the report estimates median journey-time savings, 95th percentile delay reduction, completed vehicles per hour, and people-hours saved per 1,000 journeys.
+
+## Project layout
+
+| Path | Purpose |
+| --- | --- |
+| `src/Sim.Core` | Deterministic simulation engine, vehicle models, lane policy logic, metrics, and report generation. |
+| `src/Sim.Host` | WebSocket simulation host plus `--report` mode for a terminal A/B study. |
+| `src/Sim.Client.Ascii` | Terminal visualization for watching vehicles and live metrics. |
+| `src/Sim.Client.Unity` | Unity client stub/reference integration. |
+| `tests/Sim.Core.Tests` | Determinism, lane-changing, safety, policy, metrics, and educational-report tests. |
+
+## Quick start
+
+> Requires .NET 8 SDK.
+
+### 1. Run the educational A/B report
+
+```bash
+dotnet run --project src/Sim.Host -- --report
+```
+
+Useful report options:
+
+```bash
+dotnet run --project src/Sim.Host -- --report --demand 2200 --duration 900 --warmup 180 --lanes 3 --length-km 5 --seed 20251003
+```
+
+The report compares the same road, demand, and random seed under both behaviours, then prints:
+
+- median and 95th percentile journey-time changes;
+- completed vehicles per hour;
+- right-lane and passing-lane utilization;
+- estimated people-hours saved per 1,000 journeys;
+- plain-language lessons to discuss with learners.
+
+### 2. Watch a live scenario
+
+In one terminal:
+
+```bash
+dotnet run --project src/Sim.Host -- --scenario keep-right --demand 1800
+```
+
+In a second terminal:
+
+```bash
+dotnet run --project src/Sim.Client.Ascii -- --lanes=3 --w=140 --h=38
+```
+
+Then stop the host and try the contrasting scenario:
+
+```bash
+dotnet run --project src/Sim.Host -- --scenario hog --demand 1800
+```
+
+Watch how left-lane occupation, braking waves, throughput, and trip percentiles change. In the visualization, **Lane 0 is the rightmost lane**.
+
+## Tuning scenarios
+
+`Sim.Host` accepts these options:
+
+| Option | Default | Description |
+| --- | ---: | --- |
+| `--scenario keep-right\|hog` | `keep-right` | Live scenario mix to run. |
+| `--report` | off | Run the deterministic educational A/B report and exit. |
+| `--demand <vehicles/hour>` | `1800` | Traffic demand entering the segment. |
+| `--duration <seconds>` | `600` | Report simulation duration. |
+| `--warmup <seconds>` | `120` | Report warm-up time excluded from averages. |
+| `--length-km <km>` | `5` | Highway segment length. |
+| `--lanes <count>` | `3` | Lane count. |
+| `--speed-limit <m/s>` | `33.33` | Speed limit in metres per second (`33.33` is about 120 km/h). |
+| `--seed <int>` | `20251003` | Random seed for reproducible comparisons. |
+| `--dt <seconds>` | `0.02` | Simulation timestep for report mode. |
+| `--port <port>` | `8080` | Live WebSocket host port. |
+
+## Classroom discussion prompts
+
+1. Where do queues form when a vehicle occupies the passing lane without passing?
+2. Does the keep-right case only help fast drivers, or do slower vehicles also see smoother flow?
+3. What happens to 95th percentile journey time when demand rises?
+4. Why is a predictable pass-and-return behaviour safer than undertaking and weaving?
+5. How would ramps, hills, heavy vehicles, or different speed limits change the result?
+
+## Development
+
+Run the full test suite:
+
+```bash
+dotnet test
+```
+
+The simulation is deterministic for a fixed seed, making it suitable for repeatable lessons, regression tests, and before/after policy experiments.

--- a/docs/INSTRUCTIONS.md
+++ b/docs/INSTRUCTIONS.md
@@ -5,7 +5,7 @@
 The solution is organized into three cooperating projects:
 
 - **Sim.Core** — A deterministic, pure .NET library that models highway traffic. It exposes simulation interfaces, data transfer objects, seeding utilities, metrics, and demo orchestration. This project contains no networking or Unity dependencies and can run on any .NET 8 runtime.
-- **Sim.Host** — A .NET 8 console application that embeds the core simulation, advances it at a fixed timestep, and serves realtime state over WebSockets. It accepts control commands and reports health metrics for orchestration or dashboards.
+- **Sim.Host** — A .NET 8 console application that embeds the core simulation, advances it at a fixed timestep, serves realtime state over WebSockets, and can run a deterministic `--report` A/B comparison for lessons or workshops. It accepts control commands and reports health metrics for orchestration or dashboards.
 - **Sim.Client.Unity** — A library of C# scripts that implement a minimal WebSocket client for consuming simulation snapshots within Unity or any .NET environment. Unity-specific integrations are left as comments so the code compiles in standard .NET builds.
 
 The repository also reserves **api/sim.proto** for future gRPC evolution and **tests/Sim.Core.Tests** for automated verification of the physics, policies, and determinism. The **docs** folder hosts this guide and any accompanying design documents.
@@ -113,9 +113,9 @@ Both mixes use the same vehicle class distribution.
 
 `Sensors` maintains throughput, lane occupancy, mean/variance (via Welford) of speeds, and travel time percentiles. A `SimStatsSnapshot` aggregates current metrics. The host publishes stats once per simulated second and logs summaries every simulated minute.
 
-## Demo Experiment
+## Demo Experiment and Educational Report
 
-`Experiment` constructs two independent `HighwaySim` instances with identical seeds and demand, differing only in lane policy mix. It records snapshots and stats to demonstrate how lane discipline affects throughput and variability.
+`Experiment` constructs two independent `HighwaySim` instances with identical seeds and demand, differing only in lane policy mix. It records snapshots and stats to demonstrate how lane discipline affects throughput and variability. `EducationalReport` turns that A/B run into a markdown-ready teaching summary with median journey-time savings, 95th percentile savings, throughput gain, right-lane/passing-lane utilization, and discussion lessons.
 
 ## Running the Demo Scenarios
 
@@ -131,7 +131,11 @@ dotnet run --project src/Sim.Host -- --scenario keep-right --demand 1800 --seed 
 dotnet run --project src/Sim.Host -- --scenario hog --demand 1800 --seed 42
 ```
 
-Observe console stats every simulated minute to compare throughput and variance.
+Observe console stats every simulated minute to compare throughput and variance, or generate the v1 educational report directly:
+
+```bash
+dotnet run --project src/Sim.Host -- --report --demand 1800 --duration 600 --warmup 120 --seed 42
+```
 
 ## Visualization Guidelines
 
@@ -148,13 +152,14 @@ When building a visualizer (Unity or otherwise), follow the blueprint aesthetic:
 dotnet build
 dotnet test
 dotnet run --project src/Sim.Host -- --scenario keep-right --demand 1800
+dotnet run --project src/Sim.Host -- --report
 ```
 
 ## Acceptance Criteria Checklist
 
 - Solution builds on .NET 8 without warnings.
 - `dotnet test` passes, covering IDM, MOBIL, policy biases, stats, and determinism.
-- Running the host with keep-right vs hog scenarios (same seed/demand) yields observable differences in throughput or lane metrics.
+- Running the host with keep-right vs hog scenarios (same seed/demand) yields observable differences in throughput or lane metrics, and `--report` prints a readable educational comparison.
 - WebSocket server broadcasts snapshots and deltas at the configured cadence.
 - Unity client stub connects to `ws://localhost:8080/sim` and logs received snapshots.
 - Codebase is documented, deterministic, and free of Unity dependencies in the core.

--- a/src/Sim.Client.Ascii/Program.cs
+++ b/src/Sim.Client.Ascii/Program.cs
@@ -258,7 +258,9 @@ internal sealed class WorldState
     private double _time;
     private readonly object _gate = new();
 
-    private long _vehiclesExited;
+    private double _throughputPerHour;
+    private double _travelTimeP50;
+    private double _travelTimeP95;
     private double[] _laneAvgSpeed = Array.Empty<double>();
     private double[] _laneUtil = Array.Empty<double>();
 
@@ -289,11 +291,11 @@ internal sealed class WorldState
         };
     }
 
-    public (long exited, double[] avgSpeed, double[] util) StatsSnapshot()
+    public (double throughput, double p50, double p95, double[] avgSpeed, double[] util) StatsSnapshot()
     {
         lock (_gate)
         {
-            return (_vehiclesExited, _laneAvgSpeed.ToArray(), _laneUtil.ToArray());
+            return (_throughputPerHour, _travelTimeP50, _travelTimeP95, _laneAvgSpeed.ToArray(), _laneUtil.ToArray());
         }
     }
 
@@ -364,19 +366,37 @@ internal sealed class WorldState
     {
         lock (_gate)
         {
-            if (stats.TryGetProperty("vehiclesExited", out var ex))
+            if (stats.TryGetProperty("throughputPerHour", out var throughput))
             {
-                _vehiclesExited = ex.GetInt64();
+                _throughputPerHour = throughput.GetDouble();
             }
 
-            if (stats.TryGetProperty("laneAvgSpeed", out var las) && las.ValueKind == JsonValueKind.Array)
+            if (stats.TryGetProperty("travelTimeP50", out var p50))
             {
-                _laneAvgSpeed = las.EnumerateArray().Select(e => e.GetDouble()).ToArray();
+                _travelTimeP50 = p50.GetDouble();
             }
 
-            if (stats.TryGetProperty("laneUtilization", out var lu) && lu.ValueKind == JsonValueKind.Array)
+            if (stats.TryGetProperty("travelTimeP95", out var p95))
             {
-                _laneUtil = lu.EnumerateArray().Select(e => e.GetDouble()).ToArray();
+                _travelTimeP95 = p95.GetDouble();
+            }
+
+            if (stats.TryGetProperty("meanLaneSpeeds", out var meanLaneSpeeds) && meanLaneSpeeds.ValueKind == JsonValueKind.Array)
+            {
+                _laneAvgSpeed = meanLaneSpeeds.EnumerateArray().Select(e => e.GetDouble()).ToArray();
+            }
+            else if (stats.TryGetProperty("laneAvgSpeed", out var laneAvgSpeed) && laneAvgSpeed.ValueKind == JsonValueKind.Array)
+            {
+                _laneAvgSpeed = laneAvgSpeed.EnumerateArray().Select(e => e.GetDouble()).ToArray();
+            }
+
+            if (stats.TryGetProperty("laneOccupancyShare", out var laneOccupancyShare) && laneOccupancyShare.ValueKind == JsonValueKind.Array)
+            {
+                _laneUtil = laneOccupancyShare.EnumerateArray().Select(e => e.GetDouble()).ToArray();
+            }
+            else if (stats.TryGetProperty("laneUtilization", out var laneUtilization) && laneUtilization.ValueKind == JsonValueKind.Array)
+            {
+                _laneUtil = laneUtilization.EnumerateArray().Select(e => e.GetDouble()).ToArray();
             }
         }
     }
@@ -461,7 +481,7 @@ internal sealed class Renderer
 {
     private readonly Config _cfg;
     private readonly char[,] _buf;
-    private readonly int _hudRows = 6;
+    private readonly int _hudRows = 9;
     private double _scrollOriginM;
     private double _cameraSpeedMps = 25;
     private const double LaneWidthM = 3.7; // must match host network lane width
@@ -556,10 +576,10 @@ internal sealed class Renderer
         return Math.Clamp(row, _hudRows, _cfg.ScreenH - 1);
     }
 
-    private void DrawHud(int ver, double time, int liveCount, (long exited, double[] avgSpeed, double[] util) stats)
+    private void DrawHud(int ver, double time, int liveCount, (double throughput, double p50, double p95, double[] avgSpeed, double[] util) stats)
     {
-        WriteRow(1, 1, $" Sim v{ver}  t={time,7:0.00}s  cam@{_scrollOriginM,8:0.0} m   fps~{1000 / _cfg.FrameMs}");
-        WriteRow(2, 1, $" Vehicles: live={liveCount,4}  exited={stats.exited,6}");
+        WriteRow(1, 1, $" Keep Right Sim v{ver}  t={time,7:0.00}s  cam@{_scrollOriginM,8:0.0} m   fps~{1000 / _cfg.FrameMs}");
+        WriteRow(2, 1, $" Vehicles live={liveCount,4}  throughput={stats.throughput,6:0} veh/hr  trips p50={stats.p50,5:0}s p95={stats.p95,5:0}s");
 
         var speeds = stats.avgSpeed.Length > 0
             ? string.Join(" | ", stats.avgSpeed.Select((mps, i) => $"L{i}:{mps * 3.6,5:0}kph"))
@@ -569,9 +589,12 @@ internal sealed class Renderer
             : "";
 
         WriteRow(3, 1, $" Avg lane speed: {speeds}");
-        WriteRow(4, 1, $" Lane utilization: {util}");
-        WriteRow(5, 1, " Legend: ■ car ▤ van █ truck ▓ bus ᚋ moto");
-        WriteRow(6, 1, new string('─', Math.Max(1, _cfg.ScreenW - 1)));
+        WriteRow(4, 1, $" Lane use:       {util}");
+        WriteRow(5, 1, " Lesson: the right lane is for cruising; left lanes work best when kept clear for active passing.");
+        WriteRow(6, 1, " Watch for: left-lane blockers create queues, extra braking, and slower journey times behind them.");
+        WriteRow(7, 1, " Try: host --scenario keep-right, then --scenario hog, or run host --report for an A/B summary.");
+        WriteRow(8, 1, " Legend: ■ car ▤ van █ truck ▓ bus ᚋ moto   Lane 0 is the rightmost lane");
+        WriteRow(9, 1, new string('─', Math.Max(1, _cfg.ScreenW - 1)));
     }
 
     private void DrawGrid()

--- a/src/Sim.Client.Ascii/README.md
+++ b/src/Sim.Client.Ascii/README.md
@@ -1,18 +1,31 @@
 # Sim.Client.Ascii
 
-Minimal ASCII visualizer for the highway sim host. Connects to a WebSocket server (default `ws://localhost:8080/sim`), consumes Snapshot/Delta/Stats, and renders a blueprint-style terminal view.
+Minimal ASCII visualizer for Keep Right Sim. It connects to the WebSocket host (default `ws://localhost:8080/sim`), consumes snapshot/delta/stats messages, and renders a blueprint-style terminal view with teaching prompts.
 
 ## Build
+
 ```bash
 dotnet build
 ```
 
 ## Run
+
+Start the host first:
+
 ```bash
-dotnet run --project src/Sim.Client.Ascii -- --url=ws://localhost:8080/sim --w=140 --h=36 --lanes=3 --mpercol=2.0 --fps=30
+dotnet run --project src/Sim.Host -- --scenario keep-right --demand 1800
 ```
 
-### Args
+Then run the client:
+
+```bash
+dotnet run --project src/Sim.Client.Ascii -- --url=ws://localhost:8080/sim --w=140 --h=38 --lanes=3 --mpercol=2.0 --fps=30
+```
+
+Repeat with `--scenario hog` on the host to compare lane blocking, queueing, and trip percentiles.
+
+## Args
+
 - `--url` WebSocket server (default `ws://localhost:8080/sim`)
 - `--w` / `--h` terminal width/height
 - `--lanes` lane count (visual rows)
@@ -22,15 +35,19 @@ dotnet run --project src/Sim.Client.Ascii -- --url=ws://localhost:8080/sim --w=1
 ## Protocol
 
 Expects messages:
-- `type="Snapshot"`: `{ version, time, vehicles[] }`
-- `type="Delta"`: `{ baseVersion?, version, upserts{vehicles[]}, removes{vehicles[]} }`
-- `type="Stats"`: `{ vehiclesExited, laneAvgSpeed[], laneUtilization[] }` (optional)
 
-Vehicle fields used: `id`, `lane`, `s`, optional: `d`, `yaw`, `v`, `class`, `profile`.
+- `type="snapshot"`: `{ version, time, vehicles[] }`
+- `type="delta"`: `{ baseVersion, version, upserts[], removes[] }`
+- `type="stats"`: `{ throughputPerHour, meanLaneSpeeds[], laneOccupancyShare[], travelTimeP50, travelTimeP95 }`
+
+Legacy stats names (`laneAvgSpeed`, `laneUtilization`) are also tolerated.
+
+Vehicle fields used: `id`, `laneIndex`/`lane`, `s`, optional: `d`, `yaw`, `velocity`/`v`, `vehicleClass`, `driverProfile`.
 
 ## Acceptance checklist
+
 - `dotnet build` succeeds.
 - With a running sim host, `dotnet run` connects and draws lanes + moving vehicle glyphs.
-- Works whether or not `class`/`profile` fields are present.
-- HUD shows live vehicle count, exit count, and (if provided) lane speeds/utilization.
+- HUD shows live vehicles, throughput, median/95th percentile journey time, lane speeds, lane use, and keep-right lesson prompts.
+- Works whether class/profile fields are strings or enum numbers.
 - No external packages; ANSI colors used for blueprint aesthetic.

--- a/src/Sim.Core/Demo/EducationalReport.cs
+++ b/src/Sim.Core/Demo/EducationalReport.cs
@@ -1,0 +1,156 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using Sim.Core.Metrics;
+using Sim.Core.Model;
+
+namespace Sim.Core.Demo;
+
+public sealed record ScenarioSummary(
+    string Name,
+    double MeanSpeedKph,
+    double MeanThroughputPerHour,
+    double TravelTimeP50Seconds,
+    double TravelTimeP95Seconds,
+    double RightLaneUsePercent,
+    double PassingLaneUsePercent);
+
+public sealed record EducationalComparison(
+    ScenarioSummary KeepRight,
+    ScenarioSummary Hogging,
+    double MedianJourneyTimeSavedSeconds,
+    double MedianJourneyTimeSavedPercent,
+    double PeakJourneyTimeSavedSeconds,
+    double PeakJourneyTimeSavedPercent,
+    double ThroughputGainPerHour,
+    double ThroughputGainPercent,
+    double PeopleHoursSavedPer1000Journeys,
+    IReadOnlyList<string> Lessons);
+
+public static class EducationalReport
+{
+    public static EducationalComparison Compare(
+        double durationSeconds,
+        double dt,
+        double demandPerHour,
+        int seed,
+        HighwayNetwork network,
+        double warmupSeconds = 120.0)
+    {
+        var result = Experiment.Run(durationSeconds, dt, demandPerHour, seed, network);
+        var keepRight = Summarize("Keep right except to pass", result.KeepRightStats, network.LaneCount, warmupSeconds);
+        var hogging = Summarize("Hogging / undertaking", result.HogStats, network.LaneCount, warmupSeconds);
+
+        var medianSaved = hogging.TravelTimeP50Seconds - keepRight.TravelTimeP50Seconds;
+        var peakSaved = hogging.TravelTimeP95Seconds - keepRight.TravelTimeP95Seconds;
+        var throughputGain = keepRight.MeanThroughputPerHour - hogging.MeanThroughputPerHour;
+
+        var lessons = new[]
+        {
+            "The right lane becomes the default cruising lane, so faster traffic only needs brief, predictable passes.",
+            "Fewer rolling roadblocks means less braking, less accordion traffic, and lower delay for drivers behind the pass.",
+            "The passing lane is most useful when it stays available; occupying it while not passing turns a lane into a bottleneck.",
+            "Everyone benefits: even slower vehicles get smoother flow because faster vehicles clear safely instead of tailgating or weaving."
+        };
+
+        return new EducationalComparison(
+            keepRight,
+            hogging,
+            medianSaved,
+            PercentOfBaseline(medianSaved, hogging.TravelTimeP50Seconds),
+            peakSaved,
+            PercentOfBaseline(peakSaved, hogging.TravelTimeP95Seconds),
+            throughputGain,
+            PercentOfBaseline(throughputGain, hogging.MeanThroughputPerHour),
+            Math.Max(0, medianSaved) * 1000.0 / 3600.0,
+            lessons);
+    }
+
+    public static string ToMarkdown(EducationalComparison comparison)
+    {
+        var lines = new List<string>
+        {
+            "# Keep Right Highway Simulation Report",
+            string.Empty,
+            "This deterministic A/B run compares the same road, demand, seed, and vehicle mix under two behaviours:",
+            "1. **Keep right except to pass** — drivers return right after overtaking.",
+            "2. **Hogging / undertaking** — more drivers sit left or pass on the wrong side.",
+            string.Empty,
+            "## Headline result",
+            $"- Median journey time saved: **{FormatSigned(comparison.MedianJourneyTimeSavedSeconds)} s** ({FormatSigned(comparison.MedianJourneyTimeSavedPercent)}%).",
+            $"- 95th percentile journey time saved: **{FormatSigned(comparison.PeakJourneyTimeSavedSeconds)} s** ({FormatSigned(comparison.PeakJourneyTimeSavedPercent)}%).",
+            $"- Extra vehicles completed per hour: **{FormatSigned(comparison.ThroughputGainPerHour)}** ({FormatSigned(comparison.ThroughputGainPercent)}%).",
+            $"- Time saved per 1,000 journeys: **{comparison.PeopleHoursSavedPer1000Journeys.ToString("0.0", CultureInfo.InvariantCulture)} people-hours**.",
+            string.Empty,
+            "## Scenario comparison",
+            "| Metric | Keep right | Hogging / undertaking |",
+            "| --- | ---: | ---: |",
+            $"| Mean speed | {comparison.KeepRight.MeanSpeedKph:0.0} km/h | {comparison.Hogging.MeanSpeedKph:0.0} km/h |",
+            $"| Completed vehicles/hour | {comparison.KeepRight.MeanThroughputPerHour:0} | {comparison.Hogging.MeanThroughputPerHour:0} |",
+            $"| Median journey time | {comparison.KeepRight.TravelTimeP50Seconds:0.0} s | {comparison.Hogging.TravelTimeP50Seconds:0.0} s |",
+            $"| 95th percentile journey time | {comparison.KeepRight.TravelTimeP95Seconds:0.0} s | {comparison.Hogging.TravelTimeP95Seconds:0.0} s |",
+            $"| Right-lane use | {comparison.KeepRight.RightLaneUsePercent:0.0}% | {comparison.Hogging.RightLaneUsePercent:0.0}% |",
+            $"| Passing-lane use | {comparison.KeepRight.PassingLaneUsePercent:0.0}% | {comparison.Hogging.PassingLaneUsePercent:0.0}% |",
+            string.Empty,
+            "## What to look for",
+        };
+
+        lines.AddRange(comparison.Lessons.Select(lesson => $"- {lesson}"));
+        lines.Add(string.Empty);
+        lines.Add("Tip: run the live WebSocket host and ASCII client to watch the passing lane clear when vehicles return right.");
+        return string.Join(Environment.NewLine, lines);
+    }
+
+    private static ScenarioSummary Summarize(string name, IReadOnlyList<SimStatsSnapshot> stats, int laneCount, double warmupSeconds)
+    {
+        var samples = stats.Where(s => s.Time >= warmupSeconds).ToArray();
+        if (samples.Length == 0)
+        {
+            samples = stats.ToArray();
+        }
+
+        if (samples.Length == 0)
+        {
+            return new ScenarioSummary(name, 0, 0, 0, 0, 0, 0);
+        }
+
+        var laneWeights = new double[laneCount];
+        foreach (var sample in samples)
+        {
+            for (var lane = 0; lane < Math.Min(laneCount, sample.LaneOccupancyShare.Length); lane++)
+            {
+                laneWeights[lane] += sample.LaneOccupancyShare[lane];
+            }
+        }
+
+        var speedNumerator = 0.0;
+        var speedDenominator = 0.0;
+        foreach (var sample in samples)
+        {
+            for (var lane = 0; lane < Math.Min(sample.MeanLaneSpeeds.Length, sample.LaneOccupancyShare.Length); lane++)
+            {
+                var weight = sample.LaneOccupancyShare[lane];
+                speedNumerator += sample.MeanLaneSpeeds[lane] * weight;
+                speedDenominator += weight;
+            }
+        }
+
+        var p50 = samples.Select(s => s.TravelTimeP50).Where(x => x > 0).DefaultIfEmpty(0).Average();
+        var p95 = samples.Select(s => s.TravelTimeP95).Where(x => x > 0).DefaultIfEmpty(0).Average();
+        var totalLaneWeight = laneWeights.Sum();
+
+        return new ScenarioSummary(
+            name,
+            speedDenominator > 0 ? speedNumerator / speedDenominator * 3.6 : 0,
+            samples.Average(s => s.ThroughputPerHour),
+            p50,
+            p95,
+            totalLaneWeight > 0 ? laneWeights[0] / totalLaneWeight * 100.0 : 0,
+            totalLaneWeight > 0 ? laneWeights[laneCount - 1] / totalLaneWeight * 100.0 : 0);
+    }
+
+    private static double PercentOfBaseline(double delta, double baseline) => Math.Abs(baseline) > 1e-9 ? delta / baseline * 100.0 : 0.0;
+
+    private static string FormatSigned(double value) => value.ToString("+0.0;-0.0;0.0", CultureInfo.InvariantCulture);
+}

--- a/src/Sim.Host/Program.cs
+++ b/src/Sim.Host/Program.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using Sim.Core.Demo;
 using Sim.Core.DTO;
 using Sim.Core.Model;
 using Sim.Core.Sim;
@@ -13,6 +14,20 @@ using Sim.Core.Sim.Seeding;
 
 var config = HostConfig.Parse(args);
 var network = new HighwayNetwork(config.Lanes, 3.7, config.LengthKm * 1000.0, config.SpeedLimit);
+
+if (config.Report)
+{
+    var comparison = EducationalReport.Compare(
+        config.DurationSeconds,
+        config.TimeStep,
+        config.Demand,
+        config.Seed,
+        network,
+        config.WarmupSeconds);
+    Console.WriteLine(EducationalReport.ToMarkdown(comparison));
+    return;
+}
+
 var mix = config.Scenario == Scenario.KeepRight ? TrafficMixes.KeepRightDiscipline : TrafficMixes.HogUndertake;
 var simulation = HighwaySimulationFactory.Create(network, mix);
 var seeder = new TrafficSeeder(config.Demand, config.Seed, mix);
@@ -317,6 +332,9 @@ sealed class HostConfig
     public int SnapshotInterval { get; private set; } = 5;
     public double TimeStep { get; private set; } = 0.02;
     public int Port { get; private set; } = 8080;
+    public bool Report { get; private set; }
+    public double DurationSeconds { get; private set; } = 600;
+    public double WarmupSeconds { get; private set; } = 120;
 
     public static HostConfig Parse(string[] args)
     {
@@ -349,6 +367,18 @@ sealed class HostConfig
                     break;
                 case "--port" when i + 1 < args.Length:
                     config.Port = int.Parse(args[++i]);
+                    break;
+                case "--report":
+                    config.Report = true;
+                    break;
+                case "--duration" when i + 1 < args.Length:
+                    config.DurationSeconds = double.Parse(args[++i]);
+                    break;
+                case "--warmup" when i + 1 < args.Length:
+                    config.WarmupSeconds = double.Parse(args[++i]);
+                    break;
+                case "--dt" when i + 1 < args.Length:
+                    config.TimeStep = double.Parse(args[++i]);
                     break;
             }
         }

--- a/tests/Sim.Core.Tests/EducationalReportTests.cs
+++ b/tests/Sim.Core.Tests/EducationalReportTests.cs
@@ -1,0 +1,33 @@
+using Sim.Core.Demo;
+using Sim.Core.Model;
+using Xunit;
+
+namespace Sim.Core.Tests;
+
+public class EducationalReportTests
+{
+    [Fact]
+    public void ComparisonProducesReadableEducationalSummary()
+    {
+        var network = new HighwayNetwork(LaneCount: 3, LaneWidth: 3.7, Length: 1200, SpeedLimit: 33.33);
+
+        var comparison = EducationalReport.Compare(
+            durationSeconds: 90,
+            dt: 0.05,
+            demandPerHour: 1600,
+            seed: 42,
+            network: network,
+            warmupSeconds: 15);
+
+        Assert.Equal("Keep right except to pass", comparison.KeepRight.Name);
+        Assert.Equal("Hogging / undertaking", comparison.Hogging.Name);
+        Assert.True(comparison.KeepRight.MeanSpeedKph >= 0);
+        Assert.True(comparison.Hogging.MeanSpeedKph >= 0);
+        Assert.NotEmpty(comparison.Lessons);
+
+        var markdown = EducationalReport.ToMarkdown(comparison);
+        Assert.Contains("# Keep Right Highway Simulation Report", markdown);
+        Assert.Contains("Time saved per 1,000 journeys", markdown);
+        Assert.Contains("right lane", markdown);
+    }
+}


### PR DESCRIPTION
### Motivation

- Turn the simulator into a small, classroom-ready educational tool that demonstrates why "keep right except to pass" improves flow and reduces journey times. 
- Provide a deterministic A/B experiment and a readable report so instructors can reproduce and explain measured benefits (median/95th percentile travel-time, throughput, lane-use, and people-hours saved).
- Make the live ASCII client and documentation teachable: surface the new metrics in the HUD and add simple run/compare instructions.

### Description

- Add `Sim.Core.Demo.EducationalReport` which runs the `Experiment` A/B comparison and summarizes results into `EducationalComparison` and a markdown report via `ToMarkdown`. (`src/Sim.Core/Demo/EducationalReport.cs`).
- Add host-side `--report` mode and CLI options (`--report`, `--duration`, `--warmup`, `--dt`) to run the deterministic A/B report and exit, and wire the report printing into `Sim.Host`. (`src/Sim.Host/Program.cs`).
- Update the ASCII client to consume the modern stats payload fields and show throughput plus median/95th-percentile trip times and teaching prompts in the HUD, with graceful support for legacy field names. (`src/Sim.Client.Ascii/Program.cs`).
- Refresh documentation and READMEs with quick-start report/live demo instructions and classroom discussion prompts, and add a regression unit test `EducationalReportTests` that verifies report generation and markdown content. (`README.md`, `docs/INSTRUCTIONS.md`, `src/Sim.Client.Ascii/README.md`, `tests/Sim.Core.Tests/EducationalReportTests.cs`).

### Testing

- Added the unit test `tests/Sim.Core.Tests/EducationalReportTests.cs` covering `EducationalReport.Compare` and `ToMarkdown` generation (test present in tree). 
- Attempted to run the full test suite with `dotnet test`, but the .NET SDK was not available in this environment so tests could not be executed (`dotnet: command not found`). 
- Quick repository check (`git diff --check`) reported no issues in the modified files in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a061891c7048328a49a91dae6682d30)